### PR TITLE
ci: optimize catalog-service workflow triggers

### DIFF
--- a/.github/workflows/catalog-service.yml
+++ b/.github/workflows/catalog-service.yml
@@ -6,7 +6,9 @@ on:
       - catalog-service/**
       - '.github/workflows/catalog-service.yml'
     branches:
-      - '**'
+      - 'main'
+  pull_request:
+    branches: [main]
 
 jobs:
   build:
@@ -18,7 +20,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: ${{env.working-directory}}
+        working-directory: ${{ env.working-directory }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- Limit workflow triggers to main branch pushes and PRs
- Remove triggers for non-main branch pushes
- Maintain existing Docker image publishing logic

Optimize GitHub Actions workflow trigger for catalog-service #18
