### PR TITLE
feat: Add Docker Hub deployment tasks to Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,6 +41,29 @@ tasks:
       - task: sleep
       - task: start_infra
 
+  start_using_dockerHub_image:
+    cmds:
+      - docker run -d --name catalog-db -p 15432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres postgres:17.4-alpine3.21
+      - task: sleep
+        vars:
+          DURATION: 10
+      - docker run -d --name catalog-service -p 8081:8081 -e SPRING_PROFILES_ACTIVE=docker -e DB_URL=jdbc:postgresql://host.docker.internal:15432/postgres -e DB_USERNAME=postgres -e DB_PASSWORD=postgres heymaaz/bookstore-catalog-service:latest
+      - echo "Services started! Access API at http://localhost:8081/api/products"
+
+  stop_using_dockerHub_image:
+    cmds:
+      - docker stop catalog-service catalog-db
+      - docker rm catalog-service catalog-db
+      - echo "All services stopped and removed"
+
+  restart_using_dockerHub_image:
+    cmds:
+      - task: stop_using_dockerHub_image
+      - task: sleep
+        vars:
+          DURATION: 10
+      - task: start_using_dockerHub_image
+
   start:
     deps: [build]
     cmds:
@@ -50,7 +73,6 @@ tasks:
     cmds:
       - docker compose -f "{{.INFRA_DC_FILE}}" -f "{{.APPS_DC_FILE}}" stop
       - docker compose -f "{{.INFRA_DC_FILE}}" -f "{{.APPS_DC_FILE}}" rm -f
-
   restart:
     cmds:
       - task: stop
@@ -61,4 +83,5 @@ tasks:
     vars:
       DURATION: '{{ default 5 .DURATION}}'
     cmds:
+      - echo 'sleeping for {{.DURATION}}s'
       - sleep '{{.DURATION}}'


### PR DESCRIPTION
- Add start_using_dockerHub_image task for running pre-built images
- Add stop_using_dockerHub_image task for cleanup
- Add restart_using_dockerHub_image for convenience
- Improve sleep task visibility with duration output
- Configure PostgreSQL on port 15432 to avoid conflicts
- Document API access at localhost:8081/api/products
#20
