### PR TITLE
Restrict exposed ports to localhost in Docker Compose and Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,11 +43,11 @@ tasks:
 
   start_using_dockerHub_image:
     cmds:
-      - docker run -d --name catalog-db -p 15432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres postgres:17.4-alpine3.21
+      - docker run -d --name catalog-db -p 127.0.0.1:15432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres postgres:17.4-alpine3.21
       - task: sleep
         vars:
           DURATION: 10
-      - docker run -d --name catalog-service -p 8081:8081 -e SPRING_PROFILES_ACTIVE=docker -e DB_URL=jdbc:postgresql://host.docker.internal:15432/postgres -e DB_USERNAME=postgres -e DB_PASSWORD=postgres heymaaz/bookstore-catalog-service:latest
+      - docker run -d --name catalog-service -p 127.0.0.1:8081:8081 -e SPRING_PROFILES_ACTIVE=docker -e DB_URL=jdbc:postgresql://host.docker.internal:15432/postgres -e DB_USERNAME=postgres -e DB_PASSWORD=postgres heymaaz/bookstore-catalog-service:latest
       - echo "Services started! Access API at http://localhost:8081/api/products"
 
   stop_using_dockerHub_image:

--- a/deployment/docker-compose/apps.yml
+++ b/deployment/docker-compose/apps.yml
@@ -9,7 +9,7 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=postgres
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     restart: unless-stopped
     depends_on:
       catalog-db:

--- a/deployment/docker-compose/infra.yml
+++ b/deployment/docker-compose/infra.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
     ports:
-      - "15432:5432"
+      - "127.0.0.1:15432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready", "-d", "postgres"]
       interval: 10s


### PR DESCRIPTION
- Updated ports in apps.yml and infra.yml to bind to 127.0.0.1
- Updated Taskfile to use 127.0.0.1 for all exposed ports in docker run commands
- Ensures services are only accessible from the local machine
- Improves security and consistency for local development