### PR TITLE
fix(ci): Set explicit permissions for workflow

### DIFF
--- a/.github/workflows/catalog-service.yml
+++ b/.github/workflows/catalog-service.yml
@@ -1,5 +1,6 @@
 name: Catalog Service
-
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Define explicit permissions for the CI workflow to adhere to the principle of least privilege and resolve the CodeQL `actions/missing-workflow-permissions` warning.

The workflow primarily needs to read repository contents for checkout and building. Added `permissions: contents: read` at the workflow level to restrict the GITHUB_TOKEN scope accordingly. This reduces potential security risks associated with overly broad default permissions.

Closes #25 